### PR TITLE
Add campaign orchestrator experience

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,55 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import List, Tuple
+
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-import json
-import random
-import asyncio
-from data_sources import get_data_sources
+
 from channels import get_channel_message
+from data_sources import get_data_sources
+
 
 app = FastAPI()
 
-# Serve the frontend from the static folder
-app.mount("/static", StaticFiles(directory="frontend/build/static"), name="static")
+_BASE_DIR = Path(__file__).resolve().parent
+_FRONTEND_BUILD = _BASE_DIR.parent / "frontend" / "build" / "client"
 
-@app.get("/")
-async def root():
-    return HTMLResponse(open("frontend/build/index.html").read())
 
-# WebSocket connection to send JSON data
-@app.websocket("/ws")
-async def websocket_endpoint(websocket: WebSocket):
-    await websocket.accept()
+def _safe_read_index() -> str:
+    index_path = _FRONTEND_BUILD / "index.html"
+    if index_path.exists():
+        return index_path.read_text(encoding="utf-8")
+    return """<!DOCTYPE html><html><body><p>Build the frontend to serve static assets or run the Vite dev server.</p></body></html>"""
+
+
+if _FRONTEND_BUILD.exists():
+    static_dir = _FRONTEND_BUILD / "assets"
+    if static_dir.exists():
+        app.mount("/assets", StaticFiles(directory=str(static_dir)), name="assets")
+
+    @app.get("/")
+    async def root() -> HTMLResponse:  # pragma: no cover - thin wrapper for static hosting
+        return HTMLResponse(_safe_read_index())
+
+
+def _parse_preferences(message: str) -> Tuple[List[str], List[str]]:
     try:
+        payload = json.loads(message)
+    except json.JSONDecodeError:
+        return [], []
+
+    sources = payload.get("dataSources")
+    channels = payload.get("channels")
+
+    def _normalize(value: object) -> List[str]:
+        if isinstance(value, list):
+            return [str(item) for item in value]
+        if isinstance(value, str):
+            return [value]
+        return []
+
+    return _normalize(sources), _normalize(channels)
+
+
+def _build_right_time(channel_key: str) -> dict:
+    timezone = random.choice([
+        "America/New_York",
+        "America/Los_Angeles",
+        "Europe/London",
+        "Asia/Singapore",
+    ])
+    window_minutes = random.choice([15, 30, 45, 60, 90])
+    send_at = datetime.utcnow() + timedelta(minutes=window_minutes)
+    return {
+        "send_at": send_at.replace(microsecond=0).isoformat() + "Z",
+        "time_zone": timezone,
+        "window_minutes": window_minutes,
+        "rationale": f"Optimize delivery window for {channel_key} engagement",
+    }
+
+
+def _build_metrics() -> dict:
+    return {
+        "expected_lift": f"{random.randint(4, 18)}%",
+        "confidence_score": round(random.uniform(0.55, 0.92), 2),
+        "sample_size": random.randint(1200, 4000),
+    }
+
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket) -> None:
+    await websocket.accept()
+
+    selected_sources: List[str] = []
+    selected_channels: List[str] = []
+
+    try:
+        try:
+            initial_message = await asyncio.wait_for(websocket.receive_text(), timeout=2.0)
+            selected_sources, selected_channels = _parse_preferences(initial_message)
+        except asyncio.TimeoutError:
+            selected_sources, selected_channels = [], []
+
         while True:
-            # Simulate streaming JSON output
-            data_sources = get_data_sources()
-            channel = get_channel_message()
+            data_sources, audience = get_data_sources(selected_sources)
+            channel = get_channel_message(selected_channels, audience, data_sources)
 
             payload = {
-                "campaign_id": random.randint(1000, 9999),
-                "data_sources": data_sources,
-                "channel": channel["channel"],
-                "audience": {
-                    "age": random.choice(["18-24", "25-34", "35-44"]),
-                    "location": random.choice(["New York", "California", "Texas"]),
-                    "interests": random.choice([["tech", "gaming"], ["fashion", "beauty"]]),
+                "campaignId": random.randint(1000, 9999),
+                "generatedAt": datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+                "rightTime": _build_right_time(channel["channel"]),
+                "rightChannel": {
+                    "id": channel["channel"],
+                    "name": channel["display_name"],
+                    "reason": channel["reason"],
+                    "supportingSignals": channel["supporting_signals"],
                 },
-                "message": {
-                    "subject": f"Exclusive offer on {channel['channel']}!",
-                    "body": f"Hey [User], get a special offer on your favorite items. Use code XYZ."
+                "rightMessage": {
+                    "headline": channel["headline"],
+                    "body": channel["body"],
+                    "cta": channel["cta"],
+                    "preview": channel["preview"],
+                    "tone": channel["tone"],
                 },
-                "timing": {
-                    "send_at": "2025-09-30T10:00:00Z",
-                    "time_zone": "America/New_York"
-                }
+                "rightAudience": audience,
+                "dataSources": data_sources,
+                "metrics": _build_metrics(),
             }
 
-            await websocket.send_text(json.dumps(payload))
-            await asyncio.sleep(3)  # Simulate streaming every 3 seconds
+            await websocket.send_json(payload)
+
+            try:
+                while True:
+                    update_message = await asyncio.wait_for(websocket.receive_text(), timeout=0.05)
+                    selected_sources, selected_channels = _parse_preferences(update_message)
+            except asyncio.TimeoutError:
+                pass
+
+            await asyncio.sleep(3)
 
     except WebSocketDisconnect:
-        print("Client disconnected")
-
-# Run the app with:
-# uvicorn app:app --reload
+        # Client closed the connection gracefully; nothing else to do.
+        return

--- a/backend/channels.py
+++ b/backend/channels.py
@@ -1,10 +1,117 @@
-import random
+from __future__ import annotations
 
-def get_channel_message():
-    channels = [
-        {"channel": "email", "message": "Special offer via email!"},
-        {"channel": "sms", "message": "Exclusive SMS offer!"},
-        {"channel": "whatsapp", "message": "Exclusive offer on WhatsApp!"},
-        {"channel": "ads", "message": "Targeted ads just for you!"}
-    ]
-    return random.choice(channels)
+import random
+from typing import Dict, Iterable, List
+
+
+def _pick_interest(audience: Dict[str, object]) -> str:
+    interests = audience.get("interests")
+    if isinstance(interests, list) and interests:
+        return random.choice(interests)
+    return "our newest collection"
+
+
+def _pick_behavior(audience: Dict[str, object]) -> str:
+    behaviors = audience.get("behaviors")
+    if isinstance(behaviors, list) and behaviors:
+        return random.choice(behaviors)
+    return "recent activity"
+
+
+_CHANNEL_BLUEPRINTS = {
+    "email": {
+        "label": "Email",
+        "headline": "Bring them back with a curated edit",
+        "body": (
+            "Hi {{name}}, we noticed {{behavior}}. "
+            "Showcase {{interest}} with a personalized collection and highlight "
+            "the benefits of returning now."
+        ),
+        "cta": "Shop the tailored picks",
+        "tone": "helpful",
+    },
+    "sms": {
+        "label": "SMS",
+        "headline": "Keep momentum with a short nudge",
+        "body": (
+            "Quick reminder: {{interest}} is trending right now. "
+            "Reward the last action with a time-bound perk."
+        ),
+        "cta": "Tap to redeem offer",
+        "tone": "urgent",
+    },
+    "whatsapp": {
+        "label": "WhatsApp",
+        "headline": "Start a helpful conversation",
+        "body": (
+            "Open with a friendly check-in referencing {{behavior}} and suggest "
+            "two relevant items inspired by {{interest}}. Include an embedded "
+            "carousel for rich context."
+        ),
+        "cta": "View personalized picks",
+        "tone": "conversational",
+    },
+    "ads": {
+        "label": "Ads",
+        "headline": "Retarget with dynamic creative",
+        "body": (
+            "Deploy a responsive ad set tuned to {{interest}} audiences. "
+            "Mirror the onsite experience and keep the message consistent "
+            "with their {{behavior}}."
+        ),
+        "cta": "Return to complete your journey",
+        "tone": "persuasive",
+    },
+}
+
+
+def get_channel_message(
+    selected_channels: Iterable[str] | None,
+    audience: Dict[str, object],
+    data_sources: Dict[str, Dict[str, object]],
+) -> Dict[str, object]:
+    """Return the selected channel with a tailored narrative."""
+
+    normalized = [channel.lower() for channel in selected_channels or []]
+    available = [channel for channel in normalized if channel in _CHANNEL_BLUEPRINTS]
+    if not available:
+        available = list(_CHANNEL_BLUEPRINTS.keys())
+
+    channel_key = random.choice(available)
+    blueprint = _CHANNEL_BLUEPRINTS[channel_key]
+
+    interest = _pick_interest(audience)
+    behavior = _pick_behavior(audience)
+    location = audience.get("location", "their area")
+
+    supporting_signals: List[str] = []
+    if channel_key == "ads" and "google_ads_tag" in data_sources:
+        campaign = data_sources["google_ads_tag"].get("campaign")
+        supporting_signals.append(f"Recent campaign momentum: {campaign}")
+    if channel_key == "email" and "gtm" in data_sources:
+        page_view = data_sources["gtm"].get("page_view")
+        supporting_signals.append(f"Last seen browsing {page_view}")
+    if channel_key in {"sms", "whatsapp"} and "facebook_pixel" in data_sources:
+        event = data_sources["facebook_pixel"].get("event")
+        supporting_signals.append(f"Latest conversion event: {event}")
+
+    message_body = (
+        blueprint["body"]
+        .replace("{{interest}}", interest)
+        .replace("{{behavior}}", behavior.lower())
+        .replace("{{name}}", "there")
+    )
+
+    preview = f"Focus on {interest} for {location} audiences"
+
+    return {
+        "channel": channel_key,
+        "display_name": blueprint["label"],
+        "headline": blueprint["headline"],
+        "body": message_body,
+        "cta": blueprint["cta"],
+        "tone": blueprint["tone"],
+        "preview": preview,
+        "supporting_signals": supporting_signals,
+        "reason": f"{blueprint['label']} fits {interest} interest with {behavior.lower()} context",
+    }

--- a/backend/data_sources.py
+++ b/backend/data_sources.py
@@ -1,23 +1,190 @@
+from __future__ import annotations
+
 import random
+from collections import Counter
+from typing import Dict, Iterable, List, Tuple
 
-def get_data_sources():
-    gtm_data = {
-        "page_view": "/product/xyz",
-        "user_behavior": random.choice(["abandoned_cart", "page_viewed"])
+AudienceProfile = Dict[str, object]
+SourceData = Dict[str, object]
+
+
+_AGE_RANGES = ["18-24", "25-34", "35-44", "45-54"]
+_LOCATIONS = ["New York", "California", "Texas", "Florida", "Illinois"]
+_INTEREST_BUCKETS = {
+    "gtm": ["flash sales", "new arrivals", "sustainability"],
+    "facebook_pixel": ["loyalty rewards", "community", "exclusive drops"],
+    "google_ads_tag": ["best sellers", "gift ideas", "seasonal picks"],
+}
+
+
+def _choose_age() -> str:
+    return random.choice(_AGE_RANGES)
+
+
+def _choose_location() -> str:
+    return random.choice(_LOCATIONS)
+
+
+def _gtm_payload() -> Tuple[SourceData, AudienceProfile]:
+    behavior = random.choice([
+        "abandoned_cart",
+        "category_browser",
+        "new_visitor",
+    ])
+    page = random.choice([
+        "/products/smart-speaker",
+        "/collections/summer-edit",
+        "/blog/best-of-week",
+    ])
+
+    profile: AudienceProfile = {
+        "age_range": _choose_age(),
+        "location": _choose_location(),
+        "interests": [random.choice(_INTEREST_BUCKETS["gtm"])],
+        "behaviors": ["Viewed " + page.split("/")[-1].replace("-", " ")],
+        "lifecycle_stage": random.choice(["prospect", "returning", "at-risk"]),
     }
 
-    facebook_pixel_data = {
-        "event": "purchase",
-        "value": random.choice([100, 200, 300])
+    data: SourceData = {
+        "page_view": page,
+        "recent_event": behavior,
+        "time_on_site_seconds": random.randint(30, 240),
+        "active_session": random.choice([True, False]),
     }
 
-    google_ads_data = {
-        "campaign": "product_launch",
-        "conversion": random.choice([0, 1])
+    return data, profile
+
+
+def _facebook_pixel_payload() -> Tuple[SourceData, AudienceProfile]:
+    event = random.choice(["AddToCart", "Purchase", "Lead", "ViewContent"])
+    value = round(random.uniform(35, 220), 2)
+    device = random.choice(["mobile", "desktop", "tablet"])
+
+    profile: AudienceProfile = {
+        "age_range": _choose_age(),
+        "location": _choose_location(),
+        "interests": [random.choice(_INTEREST_BUCKETS["facebook_pixel"])],
+        "behaviors": [f"Facebook Pixel event: {event}"],
+        "preferred_device": device,
     }
 
-    return {
-        "gtm": gtm_data,
-        "facebook_pixel": facebook_pixel_data,
-        "google_ads_tag": google_ads_data
+    data: SourceData = {
+        "event": event,
+        "value": value,
+        "currency": "USD",
+        "device": device,
     }
+
+    return data, profile
+
+
+def _google_ads_payload() -> Tuple[SourceData, AudienceProfile]:
+    campaign = random.choice([
+        "spring_promo",
+        "retargeting_audience",
+        "brand_awareness",
+    ])
+    conversions = random.randint(0, 12)
+    spend = round(random.uniform(120, 560), 2)
+
+    profile: AudienceProfile = {
+        "age_range": _choose_age(),
+        "location": _choose_location(),
+        "interests": [random.choice(_INTEREST_BUCKETS["google_ads_tag"])],
+        "behaviors": [f"Engaged with {campaign.replace('_', ' ')} campaign"],
+        "lifecycle_stage": random.choice(["new", "loyal", "lapsing"]),
+    }
+
+    data: SourceData = {
+        "campaign": campaign,
+        "click_through_rate": round(random.uniform(0.8, 3.4), 2),
+        "conversions": conversions,
+        "spend": spend,
+    }
+
+    return data, profile
+
+
+_SOURCE_FACTORIES = {
+    "gtm": _gtm_payload,
+    "facebook_pixel": _facebook_pixel_payload,
+    "google_ads_tag": _google_ads_payload,
+}
+
+
+def _merge_audience_hints(hints: Iterable[AudienceProfile]) -> AudienceProfile:
+    hints = list(hints)
+    if not hints:
+        # Fallback profile when nothing is selected.
+        return {
+            "age_range": _choose_age(),
+            "location": _choose_location(),
+            "interests": ["new arrivals"],
+            "behaviors": ["Browsing catalog"],
+            "lifecycle_stage": "unknown",
+        }
+
+    def _most_common(key: str) -> str:
+        values = [hint.get(key) for hint in hints if hint.get(key)]
+        if not values:
+            return "unknown"
+        if isinstance(values[0], list):
+            # Flatten lists when necessary.
+            flat_values: List[str] = [item for sub in values for item in sub]  # type: ignore[arg-type]
+            if not flat_values:
+                return "unknown"
+            return Counter(flat_values).most_common(1)[0][0]
+        return Counter(values).most_common(1)[0][0]
+
+    interests: List[str] = sorted(
+        {interest for hint in hints for interest in hint.get("interests", [])}
+    )
+    behaviors: List[str] = sorted(
+        {behavior for hint in hints for behavior in hint.get("behaviors", [])}
+    )
+
+    lifecycle = _most_common("lifecycle_stage")
+    if lifecycle == "unknown":
+        lifecycle = random.choice(["prospect", "returning", "loyal"])
+
+    profile: AudienceProfile = {
+        "age_range": _most_common("age_range"),
+        "location": _most_common("location"),
+        "interests": interests or ["general catalog"],
+        "behaviors": behaviors or ["Exploring products"],
+        "lifecycle_stage": lifecycle,
+    }
+
+    preferred_device = _most_common("preferred_device")
+    if preferred_device != "unknown":
+        profile["preferred_device"] = preferred_device
+
+    return profile
+
+
+def get_data_sources(selected_sources: Iterable[str] | None = None) -> Tuple[Dict[str, SourceData], AudienceProfile]:
+    """Return simulated source data and a blended audience profile."""
+
+    normalized = [source.lower() for source in selected_sources or []]
+    if not normalized:
+        normalized = list(_SOURCE_FACTORIES.keys())
+
+    data_sources: Dict[str, SourceData] = {}
+    audience_hints: List[AudienceProfile] = []
+
+    for source in normalized:
+        factory = _SOURCE_FACTORIES.get(source)
+        if not factory:
+            continue
+        data, audience = factory()
+        data_sources[source] = data
+        audience_hints.append(audience)
+
+    # Ensure we always have at least one data source payload.
+    if not data_sources:
+        data, audience = _gtm_payload()
+        data_sources["gtm"] = data
+        audience_hints.append(audience)
+
+    blended_audience = _merge_audience_hints(audience_hints)
+    return data_sources, blended_audience

--- a/frontend/app/features/campaign-orchestrator/campaign-orchestrator.tsx
+++ b/frontend/app/features/campaign-orchestrator/campaign-orchestrator.tsx
@@ -1,0 +1,472 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+type DataSourceId = "gtm" | "facebook_pixel" | "google_ads_tag";
+type ChannelId = "email" | "sms" | "whatsapp" | "ads";
+
+type CampaignPayload = {
+  campaignId: number;
+  generatedAt: string;
+  rightTime: {
+    send_at: string;
+    time_zone: string;
+    window_minutes: number;
+    rationale: string;
+  };
+  rightChannel: {
+    id: ChannelId;
+    name: string;
+    reason: string;
+    supportingSignals: string[];
+  };
+  rightMessage: {
+    headline: string;
+    body: string;
+    cta: string;
+    preview: string;
+    tone: string;
+  };
+  rightAudience: {
+    age_range?: string;
+    location?: string;
+    interests?: string[];
+    behaviors?: string[];
+    lifecycle_stage?: string;
+    preferred_device?: string;
+  };
+  dataSources: Record<string, unknown>;
+  metrics: {
+    expected_lift: string;
+    confidence_score: number;
+    sample_size: number;
+  };
+};
+
+type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+const DATA_SOURCES: Array<{
+  id: DataSourceId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "gtm",
+    label: "Google Tag Manager (GTM)",
+    description: "Onsite events like page views and funnels",
+  },
+  {
+    id: "facebook_pixel",
+    label: "Facebook Pixel",
+    description: "Paid social conversions and remarketing events",
+  },
+  {
+    id: "google_ads_tag",
+    label: "Google Ads",
+    description: "Campaign spend, conversions and CTR",
+  },
+];
+
+const CHANNELS: Array<{
+  id: ChannelId;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "email",
+    label: "Email",
+    description: "Rich storytelling with dynamic product blocks",
+  },
+  {
+    id: "sms",
+    label: "SMS",
+    description: "Short form alerts with instant click-through",
+  },
+  {
+    id: "whatsapp",
+    label: "WhatsApp",
+    description: "Conversational follow-up with interactive elements",
+  },
+  {
+    id: "ads",
+    label: "Ads",
+    description: "Dynamic paid placements that mirror site experience",
+  },
+];
+
+const MAX_MESSAGES = 20;
+
+function formatTimestamp(value: string): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+function StatusBadge({ status }: { status: ConnectionStatus }) {
+  const palette: Record<ConnectionStatus, string> = {
+    disconnected: "bg-gray-400",
+    connecting: "bg-amber-400",
+    connected: "bg-emerald-500",
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2 text-sm font-medium">
+      <span className={`h-2.5 w-2.5 rounded-full ${palette[status]}`} aria-hidden />
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
+}
+
+function PreferencesList<T extends string>({
+  items,
+  selected,
+  onToggle,
+  name,
+}: {
+  items: Array<{ id: T; label: string; description: string }>;
+  selected: T[];
+  onToggle: (id: T) => void;
+  name: string;
+}) {
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+        {name}
+      </legend>
+      <div className="grid gap-3 md:grid-cols-2">
+        {items.map(({ id, label, description }) => {
+          const checked = selected.includes(id);
+          return (
+            <label
+              key={id}
+              className={`flex cursor-pointer flex-col gap-1 rounded-xl border p-4 text-sm transition hover:border-blue-400 hover:shadow-sm dark:border-gray-700 dark:hover:border-blue-500 ${
+                checked
+                  ? "border-blue-500 bg-blue-50 dark:bg-blue-500/10"
+                  : "border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+              }`}
+            >
+              <span className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={checked}
+                  onChange={() => onToggle(id)}
+                />
+                <span className="font-medium">{label}</span>
+              </span>
+              <span className="text-xs text-gray-600 dark:text-gray-300">
+                {description}
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+function MessageCard({ payload }: { payload: CampaignPayload }) {
+  const { rightTime, rightChannel, rightMessage, rightAudience, metrics } = payload;
+
+  return (
+    <article className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition dark:border-gray-700 dark:bg-gray-900">
+      <header className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Campaign #{payload.campaignId} · {rightChannel.name}
+          </h3>
+          <p className="text-sm text-gray-600 dark:text-gray-300">
+            {rightChannel.reason}
+          </p>
+        </div>
+        <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-medium uppercase text-blue-600 dark:bg-blue-500/20 dark:text-blue-200">
+          Generated {formatTimestamp(payload.generatedAt)}
+        </span>
+      </header>
+
+      <dl className="mt-4 grid gap-4 md:grid-cols-2">
+        <div className="space-y-1">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Right Time
+          </dt>
+          <dd className="text-sm text-gray-800 dark:text-gray-200">
+            {formatTimestamp(rightTime.send_at)} ({rightTime.time_zone}) · {rightTime.window_minutes} min window
+          </dd>
+          <p className="text-xs text-gray-500 dark:text-gray-400">{rightTime.rationale}</p>
+        </div>
+
+        <div className="space-y-1">
+          <dt className="text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Success Forecast
+          </dt>
+          <dd className="text-sm text-gray-800 dark:text-gray-200">
+            Expected lift {metrics.expected_lift} · Confidence {metrics.confidence_score} · Sample {metrics.sample_size.toLocaleString()}
+          </dd>
+        </div>
+      </dl>
+
+      <section className="mt-4 space-y-2">
+        <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          Right Message
+        </h4>
+        <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          {rightMessage.headline}
+        </p>
+        <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+          {rightMessage.body}
+        </p>
+        <div className="text-xs uppercase tracking-wide text-blue-600 dark:text-blue-300">
+          CTA: {rightMessage.cta} · Tone: {rightMessage.tone}
+        </div>
+        {rightChannel.supportingSignals.length > 0 && (
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {rightChannel.supportingSignals.map((signal) => (
+              <li
+                key={signal}
+                className="rounded-full bg-emerald-50 px-2.5 py-1 text-xs text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-200"
+              >
+                {signal}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="mt-4 grid gap-4 md:grid-cols-2">
+        <div>
+          <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Right Audience
+          </h4>
+          <ul className="mt-2 space-y-1 text-sm text-gray-700 dark:text-gray-300">
+            {rightAudience.location && <li>Location · {rightAudience.location}</li>}
+            {rightAudience.age_range && <li>Age · {rightAudience.age_range}</li>}
+            {rightAudience.lifecycle_stage && <li>Lifecycle · {rightAudience.lifecycle_stage}</li>}
+            {rightAudience.preferred_device && <li>Preferred device · {rightAudience.preferred_device}</li>}
+            {rightAudience.interests && rightAudience.interests.length > 0 && (
+              <li>Interests · {rightAudience.interests.join(", ")}</li>
+            )}
+            {rightAudience.behaviors && rightAudience.behaviors.length > 0 && (
+              <li>Behaviors · {rightAudience.behaviors.join(", ")}</li>
+            )}
+          </ul>
+        </div>
+
+        <div>
+          <h4 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            Data Signals
+          </h4>
+          <pre className="mt-2 max-h-48 overflow-auto rounded-lg bg-gray-950/5 p-3 text-xs text-gray-700 dark:bg-gray-900 dark:text-gray-200">
+            {JSON.stringify(payload.dataSources, null, 2)}
+          </pre>
+        </div>
+      </section>
+    </article>
+  );
+}
+
+export function CampaignOrchestrator() {
+  const [selectedSources, setSelectedSources] = useState<DataSourceId[]>(
+    DATA_SOURCES.map((item) => item.id),
+  );
+  const [selectedChannels, setSelectedChannels] = useState<ChannelId[]>(
+    CHANNELS.map((item) => item.id),
+  );
+  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+  const [messages, setMessages] = useState<CampaignPayload[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+
+  const websocketUrl = useMemo(() => {
+    if (typeof window === "undefined") {
+      return "ws://localhost:8000/ws";
+    }
+    const override = (import.meta.env.VITE_WS_URL as string | undefined) ?? "";
+    if (override) {
+      return override;
+    }
+    const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+    return `${protocol}://${window.location.host}/ws`;
+  }, []);
+
+  const sendPreferences = useCallback(() => {
+    const socket = wsRef.current;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const payload = {
+      dataSources: selectedSources,
+      channels: selectedChannels,
+    };
+    socket.send(JSON.stringify(payload));
+  }, [selectedSources, selectedChannels]);
+
+  const disconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setStatus("disconnected");
+  }, []);
+
+  const connect = useCallback(() => {
+    if (typeof window === "undefined") return;
+    disconnect();
+
+    setError(null);
+    setStatus("connecting");
+
+    const socket = new WebSocket(websocketUrl);
+    wsRef.current = socket;
+
+    socket.onopen = () => {
+      setStatus("connected");
+      sendPreferences();
+    };
+
+    socket.onmessage = (event) => {
+      try {
+        const payload: CampaignPayload = JSON.parse(event.data);
+        setMessages((prev) => [payload, ...prev].slice(0, MAX_MESSAGES));
+      } catch (err) {
+        console.error("Failed to parse payload", err);
+        setError("Received an unexpected payload from the server.");
+      }
+    };
+
+    socket.onerror = () => {
+      setError("WebSocket error. Please check that the backend is running.");
+      setStatus("disconnected");
+    };
+
+    socket.onclose = () => {
+      setStatus("disconnected");
+    };
+  }, [disconnect, sendPreferences, websocketUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (status === "connected") {
+      sendPreferences();
+    }
+  }, [status, sendPreferences]);
+
+  const toggleSource = useCallback(
+    (id: DataSourceId) => {
+      setSelectedSources((prev) =>
+        prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+      );
+    },
+    [],
+  );
+
+  const toggleChannel = useCallback(
+    (id: ChannelId) => {
+      setSelectedChannels((prev) =>
+        prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id],
+      );
+    },
+    [],
+  );
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-4 py-10">
+      <header className="space-y-4">
+        <p className="text-sm font-medium text-blue-600 dark:text-blue-300">
+          Intelligent Campaign Planner
+        </p>
+        <h1 className="text-3xl font-semibold text-gray-900 dark:text-gray-50">
+          Orchestrate the right message, channel, and moment
+        </h1>
+        <p className="max-w-3xl text-sm text-gray-600 dark:text-gray-300">
+          Select the data sources that power your insights, choose the channels you want to
+          activate, and watch the orchestrator stream real-time recommendations for your next
+          campaign.
+        </p>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <StatusBadge status={status} />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={connect}
+              className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            >
+              {status === "connected" ? "Reconnect" : "Start streaming"}
+            </button>
+            <button
+              type="button"
+              onClick={disconnect}
+              disabled={status === "disconnected"}
+              className="rounded-full border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              Disconnect
+            </button>
+            <button
+              type="button"
+              onClick={() => setMessages([])}
+              className="rounded-full border border-transparent px-4 py-2 text-sm font-semibold text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Clear transcript
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="rounded-xl border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-500/40 dark:bg-red-500/10 dark:text-red-200">
+            {error}
+          </div>
+        )}
+      </header>
+
+      <section className="grid gap-6 rounded-3xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900 md:grid-cols-2">
+        <PreferencesList
+          items={DATA_SOURCES}
+          selected={selectedSources}
+          onToggle={toggleSource}
+          name="Data sources"
+        />
+        <PreferencesList
+          items={CHANNELS}
+          selected={selectedChannels}
+          onToggle={toggleChannel}
+          name="Channels"
+        />
+      </section>
+
+      <section className="flex-1 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            Real-time campaign feed
+          </h2>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            Showing up to {MAX_MESSAGES} most recent payloads
+          </span>
+        </div>
+
+        {messages.length === 0 ? (
+          <div className="flex h-48 flex-col items-center justify-center gap-2 rounded-2xl border border-dashed border-gray-300 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <span>Start streaming to see campaign recommendations appear here.</span>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {messages.map((message) => (
+              <MessageCard key={`${message.campaignId}-${message.generatedAt}`} payload={message} />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/routes/home.tsx
+++ b/frontend/app/routes/home.tsx
@@ -1,13 +1,17 @@
 import type { Route } from "./+types/home";
-import { Welcome } from "../welcome/welcome";
+import { CampaignOrchestrator } from "../features/campaign-orchestrator/campaign-orchestrator";
 
 export function meta({}: Route.MetaArgs) {
   return [
-    { title: "New React Router App" },
-    { name: "description", content: "Welcome to React Router!" },
+    { title: "Campaign Orchestrator" },
+    {
+      name: "description",
+      content:
+        "Stream AI-generated campaign recommendations across channels with live data signals.",
+    },
   ];
 }
 
 export default function Home() {
-  return <Welcome />;
+  return <CampaignOrchestrator />;
 }

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,57 @@
-Create a chat interface similar to Perplexity. The interface should allow a user to connect to various data sources. For this challenge, you can choose any 3 data sources from the list below and any 4 channels.
-* 		Data Sources: GTM, Facebook Pixel, Google Ads Tag, Facebook Page, Website, Shopify, CRMs, Twitter Page, Review Sites, Ad Managers (Meta, Google, Tiktok, etc.).
-* 		Channels: Email, SMS, Push, WhatsApp, Voice, Messenger, Ads.
-Once connected, the system should simulate streaming a JSON output representing the "right time, right channel, right message, for the right audience". This JSON payload should be structured to be later transformed into an executable campaign for the selected channels.
-Please host your solution in a public GitHub repository.
+# Campaign Orchestrator
+
+This project demonstrates an intelligent campaign planner that connects simulated marketing data sources with multiple delivery channels. The frontend presents a chat-inspired dashboard that streams JSON payloads describing the **right time**, **right channel**, **right message**, and **right audience** for each generated campaign.
+
+## Features
+
+- Select between three data sources (GTM, Facebook Pixel, Google Ads) and four activation channels (Email, SMS, WhatsApp, Ads).
+- Real-time WebSocket stream from FastAPI sends structured campaign payloads enriched with dynamic timing windows, audience profiles, and creative recommendations.
+- React interface renders payloads as conversational cards, highlighting data signals and message guidance for each channel.
+
+## Getting Started
+
+### Requirements
+
+- Node.js 18+
+- Python 3.11+
+
+### Install dependencies
+
+```bash
+cd frontend
+npm install
+
+cd ../backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Run the backend
+
+```bash
+cd backend
+uvicorn app:app --reload --host 0.0.0.0 --port 8000
+```
+
+### Run the frontend
+
+```bash
+cd frontend
+npm run dev -- --host
+```
+
+The React app expects the backend WebSocket at `ws://localhost:8000/ws`. You can override this by setting `VITE_WS_URL` in a `.env` file inside `frontend/`.
+
+## JSON Payload Structure
+
+Each streamed payload contains:
+
+- `rightTime`: send time suggestion, timezone, and delivery window rationale.
+- `rightChannel`: selected channel, reasoning, and supporting signals from the data sources.
+- `rightMessage`: headline, tone, CTA, and preview text ready for activation.
+- `rightAudience`: aggregated attributes (location, age range, behaviors, interests).
+- `dataSources`: raw telemetry from the selected integrations.
+- `metrics`: expected lift, confidence score, and sample size to inform prioritization.
+
+You can use these payloads to power future automation that executes real campaigns across the chosen channels.


### PR DESCRIPTION
## Summary
- implement a campaign orchestrator interface in React with selectable data sources and channels and a real-time campaign feed
- enrich FastAPI WebSocket stream with dynamic audience, timing, messaging, and channel reasoning data
- document setup steps and payload structure for the streaming demo

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68dab603dca0832babc36c1821444259